### PR TITLE
Also load the `/resources/conf/defaults/$CURRENT.edn` file

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject conf "0.9.1"
+(defproject conf "0.10.0"
   :description "Simple configuration/environment library for Clojure."
   :url "https://github.com/jimbru/conf"
   :license {:name "MIT License"


### PR DESCRIPTION
This adds a `defaults/` directory that can contain a resource file
that is loaded before the `$CURRENT.edn` resource.  The idea here is
that `defaults/$CURRENT.edn` can be source controlled and
`$CURRENT.edn` can be just contain the passwords and secrets unique to
the current stage.