### PR TITLE
Parse environment values into Clojure data types

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject conf "0.11.0"
+(defproject conf "0.12.0"
   :description "Simple configuration/environment library for Clojure."
   :url "https://github.com/jimbru/conf"
   :license {:name "MIT License"

--- a/src/conf/core.clj
+++ b/src/conf/core.clj
@@ -63,11 +63,22 @@
         (string/replace "." "-")
         keyword)))
 
+(defn- normalize-var-value
+  "Parses an environment variable into a Clojure type."
+  [v]
+  (try
+    (let [vparsed (edn/read-string v)]
+      (if (symbol? vparsed)
+        v
+        vparsed))
+    (catch Exception _
+      v)))
+
 (defn- normalize-var-map
   "Normalizes a config var map."
   [vmap]
   (into {} (for [[k v] vmap]
-             [(normalize-var-name k) v])))
+             [(normalize-var-name k) (normalize-var-value v)])))
 
 (defn- sys-getenv
   "Wrapper around System/getenv. Makes it easier to mock in tests."

--- a/test/conf/core_test.clj
+++ b/test/conf/core_test.clj
@@ -91,6 +91,17 @@
                  conf/load!)
   (is (= (conf/get :database-url) "sql://props:1234")))
 
+(deftest get-parsed-test
+  (wrap-fixtures {"foo" "abcdef"}
+                 {"bar" "123"
+                  "baz" ":blah"
+                  "quux" "[:a \"b\" c]"}
+                 conf/load!)
+  (is (= "abcdef" (conf/get :foo)))
+  (is (= 123 (conf/get :bar)))
+  (is (= :blah (conf/get :baz)))
+  (is (= [:a "b" 'c] (conf/get :quux))))
+
 (deftest get-not-found-arg-test
   (wrap-fixtures {} {} conf/load!)
   (is (= (conf/get :xxx) nil))


### PR DESCRIPTION
Often it's useful to have config values that are not strings. This presents
a problem however when you need to override these values via environment
variables. This change adds best-effort EDN parsing for environment variables
and JVM system properties.