### PR TITLE
Add `with-conf` & `with-overrides`

### DIFF
--- a/src/conf/core.clj
+++ b/src/conf/core.clj
@@ -48,7 +48,7 @@
 
 (declare get)
 
-(def ^:private conf (atom nil))
+(def ^:private ^:dynamic conf (atom nil))
 
 (defn- normalize-var-name
   "Environment variables are often written in UPPER_UNDERSCORE_CASE. Likewise,
@@ -181,3 +181,15 @@
   (when-not (loaded?)
     (load!))
   (swap! conf assoc k val))
+
+(defmacro with-conf
+  "Evaluates `body`, with the current config replaced by `m` (thread-locally)."
+  [m & body]
+  `(binding [conf (atom ~m)]
+     ~@body))
+
+(defmacro with-overrides
+  "Evaluates `body`, with the current config merged with `m` (thread-locally)."
+  [m & body]
+  `(with-conf (merge @@#'conf ~m)
+     ~@body))

--- a/test/conf/core_test.clj
+++ b/test/conf/core_test.clj
@@ -137,3 +137,13 @@
   (is (= (conf/get :database-url)     "sql://fake:1234/devdb"))
   (is (= (conf/get :bt-database-url)  "sql://fake:1234/devdb"))
   (is (= (conf/get :xyz-database-url) "sql://fake:1234/devdb")))
+
+(deftest with-conf-test
+  (conf/with-conf {:foo "abc"}
+    (is (= "abc" (conf/get :foo)))))
+
+(deftest with-overrides-test
+  (conf/with-conf {:foo "abc"}
+    (conf/with-overrides {:bar "123"}
+      (is (= "abc" (conf/get :foo)))
+      (is (= "123" (conf/get :bar))))))

--- a/test/conf/core_test.clj
+++ b/test/conf/core_test.clj
@@ -139,11 +139,13 @@
   (is (= (conf/get :xyz-database-url) "sql://fake:1234/devdb")))
 
 (deftest with-conf-test
-  (conf/with-conf {:foo "abc"}
-    (is (= "abc" (conf/get :foo)))))
+  (wrap-fixtures {"foo" "abc"} {} conf/load!)
+  (conf/with-conf {:bar "123"}
+    (is (nil? (conf/get :foo)))
+    (is (= "123" (conf/get :bar)))))
 
 (deftest with-overrides-test
-  (conf/with-conf {:foo "abc"}
-    (conf/with-overrides {:bar "123"}
-      (is (= "abc" (conf/get :foo)))
-      (is (= "123" (conf/get :bar))))))
+  (wrap-fixtures {"foo" "abc"} {} conf/load!)
+  (conf/with-overrides {:bar "123"}
+    (is (= "abc" (conf/get :foo)))
+    (is (= "123" (conf/get :bar)))))


### PR DESCRIPTION
These helper fns allow overriding conf values in a thread-safe way, mainly for testing.
