### PR TITLE
Add `get-required`

### DIFF
--- a/src/conf/core.clj
+++ b/src/conf/core.clj
@@ -177,7 +177,7 @@
 (defn get-required
   [k]
   (or (get k)
-      (throw (ex-info "Missing required conf key" {:conf {:key k}}))))
+      (throw (ex-info "Missing required conf key" {::key k}))))
 
 (defn set!
   "Sets the config value for the given key. This is useful when

--- a/src/conf/core.clj
+++ b/src/conf/core.clj
@@ -174,6 +174,11 @@
          (v not-found)
          v))))
 
+(defn get-required
+  [k]
+  (or (get k)
+      (throw (ex-info "Missing required conf key" {:conf {:key k}}))))
+
 (defn set!
   "Sets the config value for the given key. This is useful when
    debugging in the repl."

--- a/test/conf/core_test.clj
+++ b/test/conf/core_test.clj
@@ -149,3 +149,8 @@
   (conf/with-overrides {:bar "123"}
     (is (= "abc" (conf/get :foo)))
     (is (= "123" (conf/get :bar)))))
+
+(deftest get-required-test
+  (wrap-fixtures {} {"foo" "abc"} conf/load!)
+  (is (= "abc" (conf/get-required :foo)))
+  (is (thrown? Exception (conf/get-required :bar))))


### PR DESCRIPTION
This will make it easier to fail fast when a required conf key is missing.
