### PR TITLE
Make false required values work

### DIFF
--- a/src/conf/core.clj
+++ b/src/conf/core.clj
@@ -176,10 +176,9 @@
 
 (defn get-required
   [k]
-  (let [v (get k)]
-    (if (some? v)
-      v
-      (throw (ex-info "Missing required conf key" {::key k})))))
+  (when-not (contains? (get-all) k)
+    (throw (ex-info "Missing required conf key" {::key k})))
+  (get k))
 
 (defn set!
   "Sets the config value for the given key. This is useful when

--- a/src/conf/core.clj
+++ b/src/conf/core.clj
@@ -176,8 +176,10 @@
 
 (defn get-required
   [k]
-  (or (get k)
-      (throw (ex-info "Missing required conf key" {::key k}))))
+  (let [v (get k)]
+    (if (some? v)
+      v
+      (throw (ex-info "Missing required conf key" {::key k})))))
 
 (defn set!
   "Sets the config value for the given key. This is useful when

--- a/test/conf/core_test.clj
+++ b/test/conf/core_test.clj
@@ -153,4 +153,6 @@
 (deftest get-required-test
   (wrap-fixtures {} {"foo" "abc"} conf/load!)
   (is (= "abc" (conf/get-required :foo)))
-  (is (thrown? Exception (conf/get-required :bar))))
+  (is (thrown? Exception (conf/get-required :bar)))
+  (conf/with-overrides {:baz false}
+    (is (false? (conf/get-required :baz)))))


### PR DESCRIPTION
Only blow up `get-required` when key is not set.